### PR TITLE
Add environment file for binder

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,5 @@
+name: plot-env
+dependencies:
+  - python=3.6
+  - numpy=1.13
+  - matplotlib=2.0


### PR DESCRIPTION
A Binder showcasing the LivePlot utility would be a great addition to the repo. It's a little difficult to point out the utility of this package without seeing the convenience of plotting data on-the-fly. This environment file holds the dependencies you need to use Binder. [As an example, here's mine](https://mybinder.org/v2/gh/davidmascharka/LivePlot/master?filepath=LivePlot_Demo.ipynb).